### PR TITLE
Implement bearer token authenticated fetcher

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,4 +9,4 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 First release! What's possible with this first release:
 
 - Authenticate a Web app to a Solid Identity provider
-- Perform an authenticated fetch to a Pod Server, using a DPoP or th legacy Bearer token
+- Perform an authenticated fetch to a Pod Server, using a DPoP or the legacy Bearer token

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,4 +9,4 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 First release! What's possible with this first release:
 
 - Authenticate a Web app to a Solid Identity provider
-- Perform an authenticated fetch to a Pod Server
+- Perform an authenticated fetch to a Pod Server, using a DPoP or th legacy Bearer token


### PR DESCRIPTION
This adds a fetcher issuing requests authenticated using a bearer token. Note that requesting said bearer token, or appropriately selecting the fetcher, is outside of the scope of this PR.

# Checklist

- [X] All acceptance criteria are met.
- [X] The changelog has been updated, if applicable.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).
