### PR TITLE
Fix client registration issue in the auth code flow on NSS

### DIFF
--- a/examples/single/bundle/src/App.js
+++ b/examples/single/bundle/src/App.js
@@ -83,14 +83,10 @@ class App extends Component {
   async handleLogin(e, isPopup = false) {
     e.preventDefault();
     this.setState({ status: "loading" });
-    this.state.session
-      .login({
-        redirectUrl: new URL("http://localhost:3001/"),
-        oidcIssuer: new URL(this.state.loginIssuer)
-      })
-      .then(() => {
-        this.setState({ status: "dashboard" });
-      });
+    await this.state.session.login({
+      redirectUrl: new URL("http://localhost:3001/"),
+      oidcIssuer: new URL(this.state.loginIssuer)
+    });
   }
 
   async handleLogout(e) {
@@ -99,8 +95,7 @@ class App extends Component {
     await this.state.session.logout();
     this.setState({
       status: "login",
-      fetchBody: "",
-      session: null
+      fetchBody: ""
     });
   }
 

--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -169,10 +169,10 @@ container.register<IOidcHandler>("oidcHandlers", {
   useClass: AuthorizationCodeOidcHandler
 });
 container.register<IOidcHandler>("oidcHandlers", {
-  useClass: LegacyImplicitFlowOidcHandler
+  useClass: AuthorizationCodeWithPkceOidcHandler
 });
 container.register<IOidcHandler>("oidcHandlers", {
-  useClass: AuthorizationCodeWithPkceOidcHandler
+  useClass: LegacyImplicitFlowOidcHandler
 });
 
 container.register<IOidcHandler>("oidcHandlers", {

--- a/src/login/oidc/ClientRegistrar.ts
+++ b/src/login/oidc/ClientRegistrar.ts
@@ -63,10 +63,12 @@ export default class ClientRegistrar implements IClientRegistrar {
     // If client secret and/or client id are stored in storage, use those
     const [storedClientId, storedClientSecret] = await Promise.all([
       this.storageUtility.getForUser(options.sessionId, "clientId", {
-        secure: true
+        // FIXME: figure out how to persist secure storage at reload
+        secure: false
       }),
       this.storageUtility.getForUser(options.sessionId, "clientSecret", {
-        secure: true
+        // FIXME: figure out how to persist secure storage at reload
+        secure: false
       })
     ]);
     if (storedClientId) {
@@ -138,7 +140,10 @@ export default class ClientRegistrar implements IClientRegistrar {
         clientSecret: responseBody.client_secret
       },
       {
-        secure: true
+        // FIXME: figure out how to persist secure storage at reload
+        // Otherwise, the client info cannot be retrieved from storage, and
+        // the lib tries to re-register the client on each fetch
+        secure: false
       }
     );
     await this.storageUtility.setForUser(options.sessionId, {

--- a/src/login/oidc/oidcHandlers/LegacyImplicitFlowOidcHandler.ts
+++ b/src/login/oidc/oidcHandlers/LegacyImplicitFlowOidcHandler.ts
@@ -51,15 +51,7 @@ export default class LegacyImplicitFlowOidcHandler implements IOidcHandler {
       oidcLoginOptions.issuerConfiguration.grantTypesSupported &&
       oidcLoginOptions.issuerConfiguration.grantTypesSupported.indexOf(
         "implicit"
-      ) > -1 &&
-      // FIXME: Escape hatch to detect that we are talking to NSS and not the id broker.
-      // NSS should support auth code flow, and we should be able not
-      // to use the legacy flow at all. There is curretnly a bug in how we handle NSS's
-      // auth code flow though. Once fixed, the auth code flow can be made higher
-      // priority in the dependencies.ts file, and this bandaid can be removed.
-      oidcLoginOptions.issuerConfiguration.grantTypesSupported.indexOf(
-        "urn:ietf:params:oauth:grant-type:jwt-bearer"
-      ) === -1
+      ) > -1
     );
   }
 


### PR DESCRIPTION
For some reason, dynamic client registration information isn't persisted when interacting with NSS if stored in secure storage. If stored in insecure storage though, it works and prevents us from having to deal with the legacy token.

- [ ] I've added a unit test to test for potential regressions of this bug. (will do when investigating to secure the storage)
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).