### PR TITLE
0.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@inrupt/solid-client-authn-browser",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index",


### PR DESCRIPTION
This PR bumps the version to 0.0.7. This is a test release before the actual 0.1.0, which is why the changelog hasn't been updated.

# Checklist

- [X] I used `npm version <major|minor|patch>` to update `package.json`, inspecting the changelog to determine if the release was major, minor or patch.
- [ ] The CHANGELOG has been updated to show version and release date - https://keepachangelog.com/en/1.0.0/.
- [X] The **only** commits in this PR are:
  - the CHANGELOG update.
  - the version update.
- [X] I will make sure **not** to squash these commits, but **rebase** instead.
- [X] Once this PR is merged, I will push the tag created by `npm version ...` (e.g. `git push origin vX.X.X`).