### PR TITLE
Clears both local and in-memory storage on logout

### DIFF
--- a/__tests__/authenticatedFetch/bearer/BearerAuthenticatedFetcher.spec.ts
+++ b/__tests__/authenticatedFetch/bearer/BearerAuthenticatedFetcher.spec.ts
@@ -86,7 +86,7 @@ describe("BearerAuthenticatedFetcher", () => {
 
     it("throws if no auth token is found in storage", async () => {
       const fetcher = getBearerAuthenticatedFetcher({
-        storageUtility: mockStorageUtility({})
+        storageUtility: mockStorageUtility({}, true)
       });
       await expect(() =>
         fetcher.handle(

--- a/__tests__/authenticatedFetch/bearer/BearerAuthenticatedFetcher.spec.ts
+++ b/__tests__/authenticatedFetch/bearer/BearerAuthenticatedFetcher.spec.ts
@@ -30,7 +30,7 @@ import {
 import {
   StorageUtilityMock,
   StorageUtilityGetResponse,
-  EmptyStorageUtilityMock
+  mockStorageUtility
 } from "../../../src/storage/__mocks__/StorageUtility";
 
 describe("BearerAuthenticatedFetcher", () => {
@@ -86,7 +86,7 @@ describe("BearerAuthenticatedFetcher", () => {
 
     it("throws if no auth token is found in storage", async () => {
       const fetcher = getBearerAuthenticatedFetcher({
-        storageUtility: EmptyStorageUtilityMock
+        storageUtility: mockStorageUtility({})
       });
       await expect(() =>
         fetcher.handle(

--- a/__tests__/authenticatedFetch/dpop/DpopAuthenticatedFetcher.spec.ts
+++ b/__tests__/authenticatedFetch/dpop/DpopAuthenticatedFetcher.spec.ts
@@ -37,7 +37,7 @@ import { UrlRepresentationConverterMock } from "../../../src/util/__mocks__/UrlR
 import {
   StorageUtilityMock,
   StorageUtilityGetResponse,
-  EmptyStorageUtilityMock
+  mockStorageUtility
 } from "../../../src/storage/__mocks__/StorageUtility";
 
 describe("DpopAuthenticatedFetcher", () => {
@@ -84,7 +84,7 @@ describe("DpopAuthenticatedFetcher", () => {
 
     it("rejects configs where the token isn't available", async () => {
       const dpopAuthenticatedFetcher = getDpopAuthenticatedFetcher({
-        storageUtility: EmptyStorageUtilityMock
+        storageUtility: mockStorageUtility({})
       });
       expect(
         await dpopAuthenticatedFetcher.canHandle(

--- a/__tests__/authenticatedFetch/unauthenticated/UnautenticatedFetcher.spec.ts
+++ b/__tests__/authenticatedFetch/unauthenticated/UnautenticatedFetcher.spec.ts
@@ -32,7 +32,7 @@ import { UrlRepresentationConverterMock } from "../../../src/util/__mocks__/UrlR
 import {
   StorageUtilityMock,
   StorageUtilityGetResponse,
-  EmptyStorageUtilityMock
+  mockStorageUtility
 } from "../../../src/storage/__mocks__/StorageUtility";
 
 describe("UnauthenticatedFetcher", () => {
@@ -70,7 +70,7 @@ describe("UnauthenticatedFetcher", () => {
       const fetcher = FetcherMock;
       const unauthenticatedFetcher = getUnauthenticatedFetcher({
         fetcher: fetcher,
-        storageUtility: EmptyStorageUtilityMock
+        storageUtility: mockStorageUtility({})
       });
       const url = "http://someurl.com";
       await unauthenticatedFetcher.handle(
@@ -87,7 +87,7 @@ describe("UnauthenticatedFetcher", () => {
       const fetcher = FetcherMock;
       const unauthenticatedFetcher = getUnauthenticatedFetcher({
         fetcher: fetcher,
-        storageUtility: EmptyStorageUtilityMock
+        storageUtility: mockStorageUtility({})
       });
       const url = "http://someurl.com";
       await unauthenticatedFetcher.handle(
@@ -105,7 +105,7 @@ describe("UnauthenticatedFetcher", () => {
       const fetcher = FetcherMock;
       const unauthenticatedFetcher = getUnauthenticatedFetcher({
         fetcher: fetcher,
-        storageUtility: EmptyStorageUtilityMock
+        storageUtility: mockStorageUtility({})
       });
       const url = "http://someurl.com";
       await unauthenticatedFetcher.handle(

--- a/__tests__/login/oidc/ClientRegistrar.spec.ts
+++ b/__tests__/login/oidc/ClientRegistrar.spec.ts
@@ -24,7 +24,7 @@ import { FetcherMock } from "../../../src/util/__mocks__/Fetcher";
 import ClientRegistrar from "../../../src/login/oidc/ClientRegistrar";
 import {
   StorageUtilityMock,
-  EmptyStorageUtilityMock
+  mockStorageUtility
 } from "../../../src/storage/__mocks__/StorageUtility";
 import { IssuerConfigFetcherFetchConfigResponse } from "../../../src/login/oidc/__mocks__/IssuerConfigFetcher";
 import { Response as NodeResponse } from "node-fetch";
@@ -76,7 +76,7 @@ describe("ClientRegistrar", () => {
         /* eslint-enable @typescript-eslint/camelcase */
       );
       const clientRegistrar = getClientRegistrar({
-        storage: EmptyStorageUtilityMock
+        storage: mockStorageUtility({})
       });
       const registrationUrl = new URL("https://idp.com/register");
       expect(
@@ -113,7 +113,7 @@ describe("ClientRegistrar", () => {
 
     it("Fails if there is not registration endpoint", async () => {
       const clientRegistrar = getClientRegistrar({
-        storage: EmptyStorageUtilityMock
+        storage: mockStorageUtility({})
       });
       await expect(
         clientRegistrar.getClient(
@@ -137,7 +137,7 @@ describe("ClientRegistrar", () => {
         /* eslint-enable @typescript-eslint/camelcase */
       );
       const clientRegistrar = getClientRegistrar({
-        storage: EmptyStorageUtilityMock
+        storage: mockStorageUtility({})
       });
       const registrationUrl = new URL("https://idp.com/register");
       await expect(

--- a/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
+++ b/__tests__/login/oidc/IssuerConfigFetcher.spec.ts
@@ -25,10 +25,7 @@ import {
   FetcherMock,
   FetcherMockResponse
 } from "../../../src/util/__mocks__/Fetcher";
-import {
-  StorageUtilityMock,
-  EmptyStorageUtilityMock
-} from "../../../src/storage/__mocks__/StorageUtility";
+import { mockStorageUtility } from "../../../src/storage/__mocks__/StorageUtility";
 import IssuerConfigFetcher from "../../../src/login/oidc/IssuerConfigFetcher";
 import { IFetcher } from "../../../src/util/Fetcher";
 import { Response as NodeResponse } from "node-fetch";
@@ -39,7 +36,7 @@ import { Response as NodeResponse } from "node-fetch";
 describe("IssuerConfigFetcher", () => {
   const defaultMocks = {
     fetchResponse: FetcherMockResponse,
-    storageUtility: StorageUtilityMock
+    storageUtility: mockStorageUtility({})
   };
   function getIssuerConfigFetcher(
     mocks: Partial<typeof defaultMocks> = defaultMocks
@@ -79,7 +76,7 @@ describe("IssuerConfigFetcher", () => {
       })
     ) as unknown) as Response;
     const configFetcher = getIssuerConfigFetcher({
-      storageUtility: EmptyStorageUtilityMock,
+      storageUtility: mockStorageUtility({}),
       fetchResponse: fetchResponse
     });
 
@@ -109,7 +106,7 @@ describe("IssuerConfigFetcher", () => {
       /* eslint-enable @typescript-eslint/camelcase */
     ) as unknown) as Response;
     const configFetcher = getIssuerConfigFetcher({
-      storageUtility: EmptyStorageUtilityMock,
+      storageUtility: mockStorageUtility({}),
       fetchResponse: fetchResponse
     });
 
@@ -144,7 +141,7 @@ describe("IssuerConfigFetcher", () => {
     };
     const configFetcher = new IssuerConfigFetcher(
       mockFetcher as IFetcher,
-      EmptyStorageUtilityMock
+      mockStorageUtility({})
     );
 
     await expect(

--- a/__tests__/login/oidc/TokenRequester.spec.ts
+++ b/__tests__/login/oidc/TokenRequester.spec.ts
@@ -28,10 +28,7 @@ import {
   IssuerConfigFetcherMock,
   IssuerConfigFetcherFetchConfigResponse
 } from "../../../src/login/oidc/__mocks__/IssuerConfigFetcher";
-import {
-  StorageUtilityMock,
-  EmptyStorageUtilityMock
-} from "../../../src/storage/__mocks__/StorageUtility";
+import { StorageUtilityMock } from "../../../src/storage/__mocks__/StorageUtility";
 import {
   DpopHeaderCreatorMock,
   DpopHeaderCreatorResponse

--- a/__tests__/logout/GeneralLogoutHandler.spec.ts
+++ b/__tests__/logout/GeneralLogoutHandler.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2020 Inrupt Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+ * Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+import {
+  StorageUtilityMock,
+  mockStorageUtility
+} from "../../src/storage/__mocks__/StorageUtility";
+import "reflect-metadata";
+import { default as LogoutHandler } from "../../src/logout/GeneralLogoutHandler";
+
+describe("OidcLoginHandler", () => {
+  const defaultMocks = {
+    storageUtility: StorageUtilityMock
+  };
+  function getInitialisedHandler(
+    mocks: Partial<typeof defaultMocks> = defaultMocks
+  ): LogoutHandler {
+    return new LogoutHandler(
+      mocks.storageUtility ?? defaultMocks.storageUtility
+    );
+  }
+
+  describe("canHandle", () => {
+    it("should always be able to handle logout", async () => {
+      const logoutHandler = getInitialisedHandler({
+        storageUtility: mockStorageUtility({})
+      });
+      await expect(logoutHandler.canHandle()).resolves.toBe(true);
+    });
+  });
+
+  describe("handle", () => {
+    it("should clear the local storage (both secure and not secure) when logging out", async () => {
+      const nonEmptyStorage = mockStorageUtility({
+        someUser: { someKey: "someValue" }
+      });
+      nonEmptyStorage.setForUser(
+        "someUser",
+        { someKey: "someValue" },
+        { secure: true }
+      );
+      const logoutHandler = getInitialisedHandler({
+        storageUtility: nonEmptyStorage
+      });
+      logoutHandler.handle("someUser");
+      expect(
+        nonEmptyStorage.getForUser("someUser", "someKey", { secure: true })
+      ).toBeUndefined;
+      expect(
+        nonEmptyStorage.getForUser("someUser", "someKey", { secure: false })
+      ).toBeUndefined;
+      // This test is only necessary until the key is stored safely
+      expect(nonEmptyStorage.get("clientKey", { secure: false })).toBeUndefined;
+    });
+  });
+});

--- a/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -23,7 +23,7 @@ import "reflect-metadata";
 import { UuidGeneratorMock } from "../../src/util/__mocks__/UuidGenerator";
 import { AuthenticatedFetcherMock } from "../../src/authenticatedFetch/__mocks__/AuthenticatedFetcher";
 import { LogoutHandlerMock } from "../../src/logout/__mocks__/LogoutHandler";
-import { EmptyStorageUtilityMock } from "../../src/storage/__mocks__/StorageUtility";
+import { mockStorageUtility } from "../../src/storage/__mocks__/StorageUtility";
 import SessionInfoManager from "../../src/sessionInfo/SessionInfoManager";
 
 describe("SessionInfoManager", () => {
@@ -31,7 +31,7 @@ describe("SessionInfoManager", () => {
     uuidGenerator: UuidGeneratorMock,
     authenticatedFetcher: AuthenticatedFetcherMock,
     logoutHandler: LogoutHandlerMock,
-    storageUtility: EmptyStorageUtilityMock
+    storageUtility: mockStorageUtility({})
   };
   function getSessionInfoManager(
     mocks: Partial<typeof defaultMocks> = defaultMocks
@@ -45,7 +45,7 @@ describe("SessionInfoManager", () => {
   describe("update", () => {
     it("is not implemented yet", async () => {
       const sessionManager = getSessionInfoManager({
-        storageUtility: EmptyStorageUtilityMock
+        storageUtility: mockStorageUtility({})
       });
       expect(
         async () => await sessionManager.update("commanderCool", {})
@@ -71,7 +71,7 @@ describe("SessionInfoManager", () => {
 
     it("returns undefined if the specified storage does not contain the user", async () => {
       const sessionManager = getSessionInfoManager({
-        storageUtility: EmptyStorageUtilityMock
+        storageUtility: mockStorageUtility({})
       });
       const session = await sessionManager.get("commanderCool");
       expect(session).toBeUndefined();

--- a/__tests__/sessionInfo/SessionInfoManager.spec.ts
+++ b/__tests__/sessionInfo/SessionInfoManager.spec.ts
@@ -71,7 +71,7 @@ describe("SessionInfoManager", () => {
 
     it("returns undefined if the specified storage does not contain the user", async () => {
       const sessionManager = getSessionInfoManager({
-        storageUtility: mockStorageUtility({})
+        storageUtility: mockStorageUtility({}, true)
       });
       const session = await sessionManager.get("commanderCool");
       expect(session).toBeUndefined();

--- a/src/logout/GeneralLogoutHandler.ts
+++ b/src/logout/GeneralLogoutHandler.ts
@@ -34,7 +34,11 @@ export default class LogoutHandler implements ILogoutHandler {
   }
 
   async handle(userId: string): Promise<void> {
-    this.storageUtility.deleteAllUserData(userId);
-    // TODO: trigger onLogOut()
+    await Promise.all([
+      this.storageUtility.deleteAllUserData(userId, { secure: false }),
+      this.storageUtility.deleteAllUserData(userId, { secure: true }),
+      // FIXME: This is needed until the DPoP key is stored safely
+      this.storageUtility.delete("clientKey", { secure: false })
+    ]);
   }
 }

--- a/src/storage/__mocks__/StorageUtility.ts
+++ b/src/storage/__mocks__/StorageUtility.ts
@@ -72,47 +72,54 @@ export const StorageUtilityMock: jest.Mocked<IStorageUtility> = {
   /* eslint-enable @typescript-eslint/no-unused-vars */
 };
 
-export const EmptyStorageUtilityMock: jest.Mocked<IStorageUtility> = {
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  get: jest.fn(
-    async (key: string, options: { errorIfNull?: boolean }) => undefined
-  ),
-  set: jest.fn(async (key: string, value: string) => {
-    /* do nothing */
-  }),
-  delete: jest.fn(async (key: string) => {
-    /* do nothing */
-  }),
-  getForUser: jest.fn(
-    async (userId: string, key: string, options: { errorIfNull?: true }) =>
-      undefined
-  ),
-  setForUser: jest.fn(
-    async (
-      userId: string,
-      values: Record<string, string>,
-      options?: { secure?: boolean }
-    ) => {
-      /* do nothing */
-    }
-  ),
-  deleteForUser: jest.fn(async (userId: string, key: string) => {
-    /* do nothing */
-  }),
-  deleteAllUserData: jest.fn(async (userId: string) => {
-    /* do nothing */
-  }),
-  safeGet: jest.fn(
-    async (
-      key: string,
-      options?: Partial<{
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        schema?: Record<string, any>;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        postProcess?: (retrievedObject: any) => any;
-        userId?: string;
-      }>
-    ) => undefined
-  )
-  /* eslint-enable @typescript-eslint/no-unused-vars */
+export const mockStorageUtility = (
+  stored: Record<string, string | Record<string, string>>
+): jest.Mocked<IStorageUtility> => {
+  const store = { ...stored };
+  return {
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    get: jest.fn(async (key: string, options: { errorIfNull?: boolean }) =>
+      store[key] ? (store[key] as string) : undefined
+    ),
+    set: jest.fn(async (key: string, value: string) => {
+      store[key] = value;
+    }),
+    delete: jest.fn(async (key: string) => {
+      delete store[key];
+    }),
+    getForUser: jest.fn(
+      async (userId: string, key: string, options: { errorIfNull?: true }) =>
+        store[userId]
+          ? (store[userId] as Record<string, string>)[key]
+          : undefined
+    ),
+    setForUser: jest.fn(
+      async (
+        userId: string,
+        values: Record<string, string>,
+        options?: { secure?: boolean }
+      ) => {
+        store[userId] = values;
+      }
+    ),
+    deleteForUser: jest.fn(async (userId: string, key: string) => {
+      delete (store[userId] as Record<string, string>)[key];
+    }),
+    deleteAllUserData: jest.fn(async (userId: string) => {
+      delete store[userId];
+    }),
+    safeGet: jest.fn(
+      async (
+        key: string,
+        options?: Partial<{
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          schema?: Record<string, any>;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          postProcess?: (retrievedObject: any) => any;
+          userId?: string;
+        }>
+      ) => (store[key] ? (store[key] as string) : undefined)
+    )
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+  };
 };

--- a/src/storage/__mocks__/StorageUtility.ts
+++ b/src/storage/__mocks__/StorageUtility.ts
@@ -79,8 +79,10 @@ export const mockStorageUtility = (
   let nonSecureStore: typeof stored, secureStore: typeof stored;
   if (isSecure) {
     secureStore = { ...stored };
+    nonSecureStore = {};
   } else {
     nonSecureStore = { ...stored };
+    secureStore = {};
   }
   return {
     /* eslint-disable @typescript-eslint/no-unused-vars */


### PR DESCRIPTION
Since pieces of information are stored in both local and in-memory storage, both should be cleared on logout. This enables to log in a different IdP after logging out.

Note that the bug preventing to log in the same IdP with a different account is not in the scope of this PR.

- [x] I've added a unit test to test for potential regressions of this bug.
- [X] Commits in this PR are minimal and [have descriptive commit messages](https://chris.beams.io/posts/git-commit/).